### PR TITLE
:package: :alembic: [Feature] ETQU, lorsque j'ajoute 1 commentaire sur une demande d'amélioration, un vote est incrémenté automatiquement

### DIFF
--- a/src/Entity/Bug.php
+++ b/src/Entity/Bug.php
@@ -352,6 +352,11 @@ class Bug extends UserRequest
         return true;
     }
 
+    public function getScore(): int
+    {
+        return $this->votes->count();
+    }
+
     public function __toString(): string
     {
         return (string) $this->id;

--- a/src/Entity/Bug.php
+++ b/src/Entity/Bug.php
@@ -352,7 +352,7 @@ class Bug extends UserRequest
         return true;
     }
 
-    public function getScore(): int
+    public function getLikes(): int
     {
         return $this->votes->count();
     }

--- a/src/Entity/Feature.php
+++ b/src/Entity/Feature.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use App\Repository\FeatureRepository;
 use App\Traits\TimestampableTrait;
+use ContainerDGXjYRg\get_Console_Command_About_LazyService;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -329,5 +330,10 @@ class Feature extends UserRequest implements ExportableEntityInterface
         $this->requestedBy = $requestedBy;
 
         return $this;
+    }
+
+    public function getScore(): int
+    {
+        return $this->votes->count() + $this->comments->count();
     }
 }

--- a/src/Entity/Feature.php
+++ b/src/Entity/Feature.php
@@ -332,7 +332,7 @@ class Feature extends UserRequest implements ExportableEntityInterface
         return $this;
     }
 
-    public function getScore(): int
+    public function getLikes(): int
     {
         return $this->votes->count() + $this->comments->count();
     }

--- a/src/Entity/UserRequest.php
+++ b/src/Entity/UserRequest.php
@@ -53,7 +53,7 @@ abstract class UserRequest implements \Stringable
 
     abstract public function resolve(): static;
 
-    abstract public function getScore(): int;
+    abstract public function getLikes(): int;
 
     public function isBug(): bool
     {

--- a/src/Entity/UserRequest.php
+++ b/src/Entity/UserRequest.php
@@ -53,6 +53,8 @@ abstract class UserRequest implements \Stringable
 
     abstract public function resolve(): static;
 
+    abstract public function getScore(): int;
+
     public function isBug(): bool
     {
         return false;

--- a/templates/user_request/components/_votes.html.twig
+++ b/templates/user_request/components/_votes.html.twig
@@ -1,6 +1,6 @@
 <a class="btn btn-{{ app.user.hasVoted(request) ? '' : 'outline-' }}primary btn-sm"
    href="{{ get_vote_path(request) }}"
-        {% if request.score > 0 %}
+        {% if request.likes > 0 %}
             data-bs-toggle="tooltip"
             data-bs-placement="left"
             data-bs-html="true"
@@ -8,5 +8,5 @@
         {% endif %}
 >
     <i class="fa fa-thumbs-up"></i>
-    <span>({{ request.score }})</span>
+    <span>({{ request.likes }})</span>
 </a>

--- a/templates/user_request/components/_votes.html.twig
+++ b/templates/user_request/components/_votes.html.twig
@@ -1,6 +1,6 @@
 <a class="btn btn-{{ app.user.hasVoted(request) ? '' : 'outline-' }}primary btn-sm"
    href="{{ get_vote_path(request) }}"
-        {% if request.votes|length > 0 %}
+        {% if request.score > 0 %}
             data-bs-toggle="tooltip"
             data-bs-placement="left"
             data-bs-html="true"
@@ -8,5 +8,5 @@
         {% endif %}
 >
     <i class="fa fa-thumbs-up"></i>
-    <span>({{ request.votes|length }})</span>
+    <span>({{ request.score }})</span>
 </a>

--- a/tests/Entity/BugTest.php
+++ b/tests/Entity/BugTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\Bug;
+use App\Entity\Comment;
+use App\Entity\Vote;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class BugTest extends KernelTestCase
+{
+    public function testGetLikesWithVotesAndComments(): void
+    {
+        $feature = new Bug();
+
+        $vote1 = new Vote();
+        $vote2 = new Vote();
+        $feature->addVote($vote1);
+        $feature->addVote($vote2);
+
+        $comment1 = new Comment();
+        $comment2 = new Comment();
+        $feature->addComment($comment1);
+        $feature->addComment($comment2);
+
+        $this->assertEquals(2, $feature->getLikes());
+    }
+
+    public function testGetLikesWithOnlyComments(): void
+    {
+        $feature = new Bug();
+
+        $comment1 = new Comment();
+        $comment2 = new Comment();
+        $feature->addComment($comment1);
+        $feature->addComment($comment2);
+
+        $this->assertEquals(0, $feature->getLikes());
+    }
+
+    public function testGetLikesWithOnlyVotes(): void
+    {
+        $feature = new Bug();
+
+        $vote1 = new Vote();
+        $feature->addVote($vote1);
+
+        $this->assertEquals(1, $feature->getLikes());
+    }
+
+    public function testGetLikesWithoutVotesAndComments(): void
+    {
+        $feature = new Bug();
+
+        $this->assertEquals(0, $feature->getLikes());
+    }
+}

--- a/tests/Entity/FeatureTest.php
+++ b/tests/Entity/FeatureTest.php
@@ -43,4 +43,50 @@ class FeatureTest extends KernelTestCase
         // Assert feature having vote and comment has been deleted
         $this->assertEmpty(FeatureFactory::findBy(['id' => $id]));
     }
+
+    public function testGetLikesWithVotesAndComments(): void
+    {
+        $feature = new Feature();
+
+        $vote1 = new Vote();
+        $vote2 = new Vote();
+        $feature->addVote($vote1);
+        $feature->addVote($vote2);
+
+        $comment1 = new Comment();
+        $comment2 = new Comment();
+        $feature->addComment($comment1);
+        $feature->addComment($comment2);
+
+        $this->assertEquals(4, $feature->getLikes());
+    }
+
+    public function testGetLikesWithOnlyComments(): void
+    {
+        $feature = new Feature();
+
+        $comment1 = new Comment();
+        $comment2 = new Comment();
+        $feature->addComment($comment1);
+        $feature->addComment($comment2);
+
+        $this->assertEquals(2, $feature->getLikes());
+    }
+
+    public function testGetLikesWithOnlyVotes(): void
+    {
+        $feature = new Feature();
+
+        $vote1 = new Vote();
+        $feature->addVote($vote1);
+
+        $this->assertEquals(1, $feature->getLikes());
+    }
+
+    public function testGetLikesWithoutVotesAndComments(): void
+    {
+        $feature = new Feature();
+
+        $this->assertEquals(0, $feature->getLikes());
+    }
 }


### PR DESCRIPTION
[Ticket](https://trello.com/c/kV0UihDb/6157-etqu-lorsque-jajoute-1-commentaire-sur-une-demande-dam%C3%A9lioration-un-vote-est-incr%C3%A9ment%C3%A9-automatiquement)

Lorsqu'on ajoute qu'un utilisateur commente une demande d'amélioration, un vote est incrémenté automatiquement.
L'utilisateur doit pouvoir continuer à utiliser la fonctionnalité de base du bouton "Like".
